### PR TITLE
Fixed Bug from Issue #4

### DIFF
--- a/ManiaExchangeClient/Ui/MainWindow.xaml.cs
+++ b/ManiaExchangeClient/Ui/MainWindow.xaml.cs
@@ -62,13 +62,19 @@ namespace ManiaExchangeClient.Ui
             if (viewModel.SelectedTrack == null)
                 return;
 
-            if (TabControl.SelectedIndex == 2 && viewModel.SelectedTrack.ReplayCount == 0)
+            if (TabControl.SelectedIndex == 2)
             {
-                TabControl.SelectedIndex = 0;
+                if (viewModel.SelectedTrack.ReplayCount == 0)
+                    TabControl.SelectedIndex = 0;
+                else
+                    ReplayControl.LoadData(viewModel.SelectedTrack.TrackId);
             }
-            else if (TabControl.SelectedIndex == 3 && viewModel.SelectedTrack.EmbeddedObjectsCount == 0)
+            else if (TabControl.SelectedIndex == 3)
             {
-                TabControl.SelectedIndex = 0;
+                if (viewModel.SelectedTrack.EmbeddedObjectsCount == 0)
+                    TabControl.SelectedIndex = 0;
+                else
+                    ObjectControl.LoadData(viewModel.SelectedTrack.TrackId);
             }
         }
 


### PR DESCRIPTION
# Fixed Bug from [Issue #4](https://github.com/InvaderZim85/ManiaExchangeClient/issues/4)

**Issue:**
If you change the track then the replays of the previous track are displayed and only by changing the tabs the replays will be reloaded.

**Solution:**
If you change the track then the replays are reloaded.